### PR TITLE
Magento 2.4.9 | Add int return type to console commands for Symfony 7 compatibility

### DIFF
--- a/Console/Command/AllCommand.php
+++ b/Console/Command/AllCommand.php
@@ -27,7 +27,7 @@ class AllCommand extends CommandAbstract
      * @param OutputInterface $output
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->cacheBust->bustAll();
         $output->writeln('<info>All URLs cache busted successfully.</info>');

--- a/Console/Command/MediaCommand.php
+++ b/Console/Command/MediaCommand.php
@@ -27,7 +27,7 @@ class MediaCommand extends CommandAbstract
      * @param OutputInterface $output
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->cacheBust->bustMedia();
         $output->writeln('<info>Media URLs cache busted successfully.</info>');

--- a/Console/Command/StaticCommand.php
+++ b/Console/Command/StaticCommand.php
@@ -27,7 +27,7 @@ class StaticCommand extends CommandAbstract
      * @param OutputInterface $output
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->cacheBust->bustStatic();
         $output->writeln('<info>Static URLs cache busted successfully.</info>');


### PR DESCRIPTION
## Description
Magento 2.4.9 ships Symfony Console 7.4 where `Command::execute()` has a native `int` return type. Our commands override it without the return type, causing a PHP fatal error on any `bin/magento` run:

```
Fatal error: Declaration of Absolute\CacheBust\Console\Command\AllCommand::execute(...) must be compatible with Symfony\Component\Console\Command\Command::execute(...): int
```

Adding `: int` is backward compatible with Symfony 5/6 (Magento <= 2.4.8), so no version split is needed.

## Changelog
### Fixed
- Console commands no longer crash on Magento 2.4.9 (Symfony 7)